### PR TITLE
Methics Demo SSCD

### DIFF
--- a/app/src/main/java/fi/methics/musap/sdk/api/MusapException.java
+++ b/app/src/main/java/fi/methics/musap/sdk/api/MusapException.java
@@ -1,12 +1,26 @@
 package fi.methics.musap.sdk.api;
 
+import java.security.GeneralSecurityException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * MUSAP Exception contains MUSAP specific extra details about errors including:
+ * <ul>
+ *     <li>Error Code: Error specific code (based on MUSAP specification)</li>
+ *     <li>Error Name: Human/Machine readable name of the error</li>
+ * </ul>
+ */
 public class MusapException extends Exception {
 
     public static final int ERROR_WRONG_PARAM   = 101;
     public static final int ERROR_MISSING_PARAM = 102;
+    public static final int ERROR_INVALID_ALGORITHM = 103;
     public static final int ERROR_UNKNOWN_KEY   = 105;
     public static final int ERROR_UNSUPPORTED_DATA = 107;
     public static final int ERROR_KEYGEN_UNSUPPORTED = 108;
+    public static final int ERROR_BIND_UNSUPPORTED = 109;
     public static final int ERROR_TIMED_OUT     = 208;
     public static final int ERROR_USER_CANCEL   = 401;
     public static final int ERROR_KEY_BLOCKED   = 402;
@@ -18,7 +32,15 @@ public class MusapException extends Exception {
 
     public MusapException(Exception cause) {
         super(cause);
-        this.errorCode = ERROR_INTERNAL;
+        if (cause instanceof MusapException) {
+            this.errorCode = ((MusapException)cause).getErrorCode();
+        } else if (cause instanceof InvalidAlgorithmParameterException || cause instanceof NoSuchAlgorithmException) {
+            this.errorCode = ERROR_INVALID_ALGORITHM;
+        } else if (cause instanceof InvalidKeyException) {
+            this.errorCode = ERROR_KEY_BLOCKED;
+        } else {
+            this.errorCode = ERROR_INTERNAL;
+        }
         this.errorName = getErrorName(errorCode);
     }
 
@@ -47,7 +69,7 @@ public class MusapException extends Exception {
     }
     /**
      * Get a human/machine readable name for this error
-     * @return error name (e.g. "internal_error"
+     * @return error name (e.g. "internal_error")
      */
     public String getErrorName() {
         return this.errorName;
@@ -55,7 +77,7 @@ public class MusapException extends Exception {
 
     /**
      * Get ErrorCode
-     * @return
+     * @return error code as integer
      */
     public int getErrorCode() {
         return this.errorCode;

--- a/app/src/main/java/fi/methics/musap/sdk/sscd/android/AndroidKeystoreSscd.java
+++ b/app/src/main/java/fi/methics/musap/sdk/sscd/android/AndroidKeystoreSscd.java
@@ -16,6 +16,7 @@ import java.security.spec.RSAKeyGenParameterSpec;
 import java.util.Arrays;
 
 import fi.methics.musap.sdk.api.MusapConstants;
+import fi.methics.musap.sdk.api.MusapException;
 import fi.methics.musap.sdk.extension.MusapSscdInterface;
 import fi.methics.musap.sdk.internal.datatype.KeyURI;
 import fi.methics.musap.sdk.internal.datatype.KeyAlgorithm;
@@ -97,7 +98,6 @@ public class AndroidKeystoreSscd implements MusapSscdInterface<AndroidKeystoreSe
         }
 
         SignatureAlgorithm algorithm = req.getAlgorithm();
-
         MLog.d("Signing " + MBase64.toBase64String(req.getData()) + " with algorithm " + algorithm);
         Signature s = Signature.getInstance(algorithm.getJavaAlgorithm());
         s.initSign(((KeyStore.PrivateKeyEntry) entry).getPrivateKey());


### PR DESCRIPTION
Enable seamless support for Methics Demo SSCD (activated via https://demo.methics.fi/appactivation/).

MUSAP can now properly poll for the response asynchronously to allow user to return to MUSAP for the signature result.